### PR TITLE
change to current api endpoint (/api/v1/states/daily.json); remove deprecated fields & alphabetize

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple Tableau Web Data Connector for the COVID Tracking Project API
 ## Getting Started
 
 In Tableau, connect using Web Data Connector.
-Type https://stefanba3.github.io/CovidTrackingWDC/index.html into the address bar. 
+Type https://liamcryan.github.io/CovidTrackingWDC/index.html into the address bar. 
 
 ### Prerequisites
 

--- a/covid-tracking-project-WDC.js
+++ b/covid-tracking-project-WDC.js
@@ -92,7 +92,7 @@
     };
 
     myConnector.getData = function (table, doneCallback) {
-        var query = "https://covidtracking.com/api/v1/states/daily.json"
+        var query = "https://raw.githubusercontent.com/liamcryan/covid-snapshot/master/covid-tracking-states-daily.json"
         $.getJSON(query, function(response) {
             table.appendRows(response);
             doneCallback();

--- a/covid-tracking-project-WDC.js
+++ b/covid-tracking-project-WDC.js
@@ -3,67 +3,82 @@
 
     myConnector.getSchema = function (schemaCallback) {
         var cols = [{
+            id: "dataQualityGrade",
+            dataType: tableau.dataTypeEnum.string
+        }, {
             id: "date",
             dataType: tableau.dataTypeEnum.string
         }, {
-            id: "state",
+            id: "death",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "deathConfirmed",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "deathIncrease",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "deathProbable",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: 'fips',
             dataType: tableau.dataTypeEnum.string
         }, {
-            id: "positive",
-            dataType: tableau.dataTypeEnum.int
-        }, {
-            id: "negative",
-            dataType: tableau.dataTypeEnum.int
-        }, {
-            id: "pending",
+            id: "hospitalizedCumulative",
             dataType: tableau.dataTypeEnum.int
         }, {
             id: "hospitalizedCurrently",
             dataType: tableau.dataTypeEnum.int
         }, {
-            id: "hospitalizedCumulative",
-            dataType: tableau.dataTypeEnum.int
-        }, {
-            id: "inIcuCurrently",
+            id: "hospitalizedIncrease",
             dataType: tableau.dataTypeEnum.int
         }, {
             id: "inIcuCumulative",
             dataType: tableau.dataTypeEnum.int
         }, {
-            id: "onVentilatorCurrently",
+            id: "inIcuCurrently",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "lastUpdateEt",
+            dataType: tableau.dataTypeEnum.string
+        }, {
+            id: "negative",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "negativeTestsViral",
             dataType: tableau.dataTypeEnum.int
         }, {
             id: "onVentilatorCumulative",
             dataType: tableau.dataTypeEnum.int
         }, {
-            id: "recovered",
+            id: "onVentilatorCurrently",
             dataType: tableau.dataTypeEnum.int
         }, {
-            id: "hospitalized",
+            id: "pending",
             dataType: tableau.dataTypeEnum.int
         }, {
-            id: "totalTestResults",
+            id: "positive",
             dataType: tableau.dataTypeEnum.int
         }, {
-            id: "death",
-            dataType: tableau.dataTypeEnum.int
-        }, {
-            id: "dateChecked",
-            dataType: tableau.dataTypeEnum.string
-        }, {
-            id: "deathIncrease",
-            dataType: tableau.dataTypeEnum.int
-        }, {
-            id: "hospitalizedIncrease",
-            dataType: tableau.dataTypeEnum.int
-        }, {
-            id: "negativeIncrease",
+            id: "positiveCasesViral",
             dataType: tableau.dataTypeEnum.int
         }, {
             id: "positiveIncrease",
             dataType: tableau.dataTypeEnum.int
         }, {
+            id: "recovered",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "state",
+            dataType: tableau.dataTypeEnum.string
+        }, {
+            id: "totalTestResults",
+            dataType: tableau.dataTypeEnum.int
+        }, {
             id: "totalTestResultsIncrease",
+            dataType: tableau.dataTypeEnum.int
+        }, {
+            id: "totalTestsViral",
             dataType: tableau.dataTypeEnum.int
         }];
 
@@ -77,7 +92,7 @@
     };
 
     myConnector.getData = function (table, doneCallback) {
-        var query = "https://covidtracking.com/api/states/daily"
+        var query = "https://covidtracking.com/api/v1/states/daily.json"
         $.getJSON(query, function(response) {
             table.appendRows(response);
             doneCallback();
@@ -86,7 +101,7 @@
 
     tableau.registerConnector(myConnector);
 
-    $(document).ready(function() {     
+    $(document).ready(function() {
         $("#submitButton").click(function() {
             tableau.connectionName = "COVID Tracking Project Tableau Web Data Connector";
             tableau.submit();


### PR DESCRIPTION
It looks like the updated API is:

 /api/v1/states/daily.json 

See https://covidtracking.com/data/api -> Historic values for all states.

I updated the fields: alphabetize to find a little easier, remove deprecated fields and included any newer ones.

